### PR TITLE
version 0.1.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val root = (project in file(".")).settings(
   crossScalaVersions := Seq("2.11.8", "2.12.0"),
   organization := "com.realitygames",
   name := "couchbase-java-sdk-scala-wrapper",
-  version := "0.1.2-SNAPSHOT",
+  version := "0.1.3",
 
   libraryDependencies ++= Seq(
     "com.couchbase.client" % "java-client" % "2.3.5",


### PR DESCRIPTION
I had to bump the version because for some reason 0.1.2 was already been used, so we need to bump to make it unambiguous